### PR TITLE
Fixed markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You can directly jump in source-code. It's commented.
 Codesandboxes - Please refresh your browser if apps in codesandbox are hibernated.
 
 Server - [https://codesandbox.io/s/web-terminal-tutorial-server-g2ihu](https://codesandbox.io/s/web-terminal-tutorial-server-g2ihu)
+
 Client - [https://codesandbox.io/s/web-terminal-turorial-client-sgjgg](https://codesandbox.io/s/web-terminal-turorial-client-sgjgg)
 
 


### PR DESCRIPTION
The 'Server' and 'Client' segments were rendering on the same line before